### PR TITLE
feat: add level selector in main menu

### DIFF
--- a/include/LevelMap.h
+++ b/include/LevelMap.h
@@ -18,7 +18,7 @@ public:
 		: is_enemyturn(false), player_(nullptr), window_(window) {}
 
 	// CONSTRUCTOR HELPERS
-	void Init();
+	void Init(int level);
 	void BuildAsDebug();
 	void BuildFromFile(std::string path);
 

--- a/include/LevelMap.h
+++ b/include/LevelMap.h
@@ -34,6 +34,7 @@ public:
 	Player* GetPlayer() { return player_; }
 	Entity* GetEntityAt(const sf::Vector2i& gridpos);
 	Entity* GetEntityAt(const size_t& i);
+	bool EnemiesExist() const { return entities_.size() > 1; }
 	Block* GetBlockAt(const sf::Vector2i& gridpos);
 	Block* GetBlockAt(const size_t& i);
 	Collectible* GetCollectibleAt(const sf::Vector2i& gridpos);

--- a/include/MainMenuState.h
+++ b/include/MainMenuState.h
@@ -2,14 +2,17 @@
 
 #include "GameState.h"
 
+#include <array>
 #include <unordered_map>
 
 constexpr std::string_view PROJECT_NAME = "Kobushi Solver";
 
+constexpr std::array<int, 3> LEVELS = { 1, 3, 4 };
+
 class MainMenuState : public GameState
 {
 public:
-	MainMenuState(StateManager* state_manager) : GameState(state_manager) {}
+	MainMenuState(StateManager* state_manager) : GameState(state_manager), selected_level_(4) {}
 	~MainMenuState() override = default;
 
 	void Init() override;
@@ -20,6 +23,8 @@ public:
 private:
 	// ELEMENTS
 	std::unordered_map<std::string, sf::Text> elements_;
+	int selected_level_;
 
 	void LayoutElements();
+	void ChangeLevel(int level);
 };

--- a/include/MainMenuState.h
+++ b/include/MainMenuState.h
@@ -6,13 +6,14 @@
 #include <unordered_map>
 
 constexpr std::string_view PROJECT_NAME = "Kobushi Solver";
+constexpr int DEFAULT_LEVEL = 3;
 
 constexpr std::array<int, 3> LEVELS = { 1, 3, 4 };
 
 class MainMenuState : public GameState
 {
 public:
-	MainMenuState(StateManager* state_manager) : GameState(state_manager), selected_level_(4) {}
+	MainMenuState(StateManager* state_manager) : GameState(state_manager), selected_level_(DEFAULT_LEVEL) {}
 	~MainMenuState() override = default;
 
 	void Init() override;

--- a/include/StateManager.h
+++ b/include/StateManager.h
@@ -29,10 +29,14 @@ public:
 
 	inline WindowContext& GetWindowContext() { return window_; }
 	inline sf::Font& GetFont() { return font_; }
+	inline int GetCurrentLevel() const { return current_level_; }
+	inline void SetCurrentLevel(int level) { current_level_ = level; }
 private:
 	std::map<StateID, std::unique_ptr<GameState>> states_;
 	GameState* active_state_;
 
 	WindowContext& window_;
 	sf::Font font_;
+
+	int current_level_;
 };

--- a/src/Block.cc
+++ b/src/Block.cc
@@ -20,28 +20,30 @@ void Block::Update(const sf::Time& delta)
 	if (state_ != BlockState::kFill)
 	{
 		// Check if the block can be pushed in each direction	
-		if (level->DoesCollide(GetGridPosition(), GetGridPosition() + sf::Vector2i(0, -1)))
+		if (level->DoesCollide(gridpos_, gridpos_ + sf::Vector2i(0, -1)))
 			is_pushable_[0] = true; // North
-		if (level->DoesCollide(GetGridPosition(), GetGridPosition() + sf::Vector2i(1, 0)))
+		if (level->DoesCollide(gridpos_, gridpos_ + sf::Vector2i(1, 0)))
 			is_pushable_[1] = true; // East
-		if (level->DoesCollide(GetGridPosition(), GetGridPosition() + sf::Vector2i(0, 1)))
+		if (level->DoesCollide(gridpos_, gridpos_ + sf::Vector2i(0, 1)))
 			is_pushable_[2] = true; // South
-		if (level->DoesCollide(GetGridPosition(), GetGridPosition() + sf::Vector2i(-1, 0)))
+		if (level->DoesCollide(gridpos_, gridpos_ + sf::Vector2i(-1, 0)))
 			is_pushable_[3] = true; // West
 
 		// Check if the player is adjacent to the block
 		sf::Vector2i player_pos = level->GetPlayer()->GetGridPosition();
-		if (player_pos == GetGridPosition() + sf::Vector2i({ 0, -1 }) ||
-			player_pos == GetGridPosition() + sf::Vector2i({ 1,  0 }) ||
-			player_pos == GetGridPosition() + sf::Vector2i({ 0,  1 }) ||
-			player_pos == GetGridPosition() + sf::Vector2i({ -1,  0 }))
+		if (player_pos == gridpos_ + sf::Vector2i({ 0, -1 }) ||
+			player_pos == gridpos_ + sf::Vector2i({ 1,  0 }) ||
+			player_pos == gridpos_ + sf::Vector2i({ 0,  1 }) ||
+			player_pos == gridpos_ + sf::Vector2i({ -1,  0 }))
 			is_adjacent = true;
 		else
 			is_adjacent = false;
+
+		Layout();
 	}
 
 	// Handle specific block type logic
-	Tile* tile = level->GetTileAt(GetGridPosition());
+	Tile* tile = level->GetTileAt(gridpos_);
 	if ((tile->GetType() == TileType::kWater) && (state_ != BlockState::kFill))
 	{
 		tile->SetType(TileType::kEmpty);

--- a/src/LevelMap.cc
+++ b/src/LevelMap.cc
@@ -12,7 +12,7 @@ Direction GetOpposite(Direction d)
 	return static_cast<Direction>((static_cast<int>(d) + 2) % 4);
 }
 
-void LevelMap::Init()
+void LevelMap::Init(int level)
 {
 	// RESET LEVEL MAP
 	tiles_.clear();
@@ -29,7 +29,8 @@ void LevelMap::Init()
 			tiles_.push_back(std::make_unique<Tile>(tile));
 		}
 
-	BuildFromFile(MAP_LOADED);
+	std::string path = "res/lv" + std::to_string(level) + ".map";
+	BuildFromFile(path);
 	// BuildAsDebug(); // Uncomment this line to build a debug map
 }
 

--- a/src/MainMenuState.cc
+++ b/src/MainMenuState.cc
@@ -27,7 +27,7 @@ void MainMenuState::Init()
 
 	// LEVEL SELECTOR
 	elements_.at("level").setCharacterSize(30);
-	elements_.at("level").setString("Level: 4");
+	elements_.at("level").setString("Level: " + std::to_string(DEFAULT_LEVEL));
 
 	elements_.at("next_lv").setCharacterSize(30);
 	elements_.at("next_lv").setString("Next");

--- a/src/MainMenuState.cc
+++ b/src/MainMenuState.cc
@@ -49,8 +49,7 @@ void MainMenuState::HandleInput(const sf::Event event)
 
 	// MOUSEOVER
 	const std::array<std::string, 3> buttons = { "start", "next_lv", "prev_lv" };
-	for (auto& [key, element] : elements_)
-	{
+	for (auto& [key, element] : elements_) {
 		if (std::find(buttons.begin(), buttons.end(), key) != buttons.end())
 			if (element.getGlobalBounds().contains(mouse_pos))
 				element.setStyle(sf::Text::Bold);
@@ -59,8 +58,7 @@ void MainMenuState::HandleInput(const sf::Event event)
 	}
 	
 	// MOUSE BUTTON
-	if (const auto* btn_pressed = event.getIf<sf::Event::MouseButtonPressed>())
-	{
+	if (const auto* btn_pressed = event.getIf<sf::Event::MouseButtonPressed>()) {
 		bool left_clicked = btn_pressed->button == sf::Mouse::Button::Left;
 		bool start_hovered = elements_.at("start").getGlobalBounds().contains(mouse_pos);
 		bool next_hovered = elements_.at("next_lv").getGlobalBounds().contains(mouse_pos);
@@ -71,14 +69,15 @@ void MainMenuState::HandleInput(const sf::Event event)
 				ChangeLevel(1);
 			else if (prev_hovered)
 				ChangeLevel(-1);
-			else if (start_hovered)
+			else if (start_hovered) {
+				state_manager_->SetCurrentLevel(selected_level_);
 				state_manager_->ChangeState(StateID::kSimulation);
+			}
 		}
 	}
 
 	// KEYBOARD
-	if (const auto* key = event.getIf<sf::Event::KeyPressed>())
-	{
+	if (const auto* key = event.getIf<sf::Event::KeyPressed>()) {
 		switch (key->code) {
 		case sf::Keyboard::Key::Right:	ChangeLevel(1);		break;
 		case sf::Keyboard::Key::Left:	ChangeLevel(-1);	break;
@@ -125,8 +124,7 @@ void MainMenuState::ChangeLevel(int offset)
 	if (offset > 0) {
 		selected_level_ = (selected_level_ % 4) + 1;						// Cycle forwards (i.e. 4 -> 1)
 		if (selected_level_ == 2) selected_level_ = 3;						// COMPROMISE: Skip level 2
-	}
-	else {
+	} else {
 		selected_level_ = (selected_level_ == 1) ? 4 : selected_level_ - 1;	// Cycle backwards (i.e. 1 -> 4)
 		if (selected_level_ == 2) selected_level_ = 1;						// COMPROMISE: Skip level 2
 	}

--- a/src/MainMenuState.cc
+++ b/src/MainMenuState.cc
@@ -43,6 +43,13 @@ void MainMenuState::HandleInput(const sf::Event event)
 			elements_.at("start").getGlobalBounds().contains(mouse_pos))
 			state_manager_->ChangeState(StateID::kSimulation);
 	}
+
+	if (const auto* key_pressed = event.getIf<sf::Event::KeyPressed>())
+	{
+		if (key_pressed->code == sf::Keyboard::Key::Enter ||
+			key_pressed->code == sf::Keyboard::Key::Space)
+			state_manager_->ChangeState(StateID::kSimulation);
+	}
 }
 
 void MainMenuState::Render(sf::RenderTarget& target)

--- a/src/MainMenuState.cc
+++ b/src/MainMenuState.cc
@@ -8,18 +8,35 @@ void MainMenuState::Init()
 	// FONT
 	sf::Font& font = state_manager_->GetFont();
 
-	// TITLE TEXT
+	// ELEMENTS
 	elements_.emplace("title", sf::Text(font));
+	elements_.emplace("level", sf::Text(font));
+	elements_.emplace("start", sf::Text(font));
+	elements_.emplace("next_lv", sf::Text(font));
+	elements_.emplace("prev_lv", sf::Text(font));
+
+	for (auto& [key, text] : elements_) {
+		text.setStyle(sf::Text::Regular);
+		text.setFillColor(sf::Color::White);
+	}
+
+	// TITLE TEXT
 	elements_.at("title").setCharacterSize(100);
 	elements_.at("title").setStyle(sf::Text::Bold);
-	elements_.at("title").setFillColor(sf::Color::White);
 	elements_.at("title").setString(std::string(PROJECT_NAME));
 
+	// LEVEL SELECTOR
+	elements_.at("level").setCharacterSize(30);
+	elements_.at("level").setString("Level: 4");
+
+	elements_.at("next_lv").setCharacterSize(30);
+	elements_.at("next_lv").setString("Next");
+
+	elements_.at("prev_lv").setCharacterSize(30);
+	elements_.at("prev_lv").setString("Prev");
+
 	// START BUTTON
-	elements_.emplace("start", sf::Text(font));
 	elements_.at("start").setCharacterSize(50);
-	elements_.at("start").setStyle(sf::Text::Regular);
-	elements_.at("start").setFillColor(sf::Color::White);
 	elements_.at("start").setString("PLAY");
 
 	LayoutElements();
@@ -31,31 +48,53 @@ void MainMenuState::HandleInput(const sf::Event event)
 	sf::Vector2f mouse_pos = static_cast<sf::Vector2f>(sf::Mouse::getPosition(window));
 
 	// MOUSEOVER
-	if (elements_.at("start").getGlobalBounds().contains(mouse_pos))
-		elements_.at("start").setStyle(sf::Text::Bold);
-	else
-		elements_.at("start").setStyle(sf::Text::Regular);
+	const std::array<std::string, 3> buttons = { "start", "next_lv", "prev_lv" };
+	for (auto& [key, element] : elements_)
+	{
+		if (std::find(buttons.begin(), buttons.end(), key) != buttons.end())
+			if (element.getGlobalBounds().contains(mouse_pos))
+				element.setStyle(sf::Text::Bold);
+			else
+				element.setStyle(sf::Text::Regular);
+	}
 	
 	// MOUSE BUTTON
 	if (const auto* btn_pressed = event.getIf<sf::Event::MouseButtonPressed>())
 	{
-		if (btn_pressed->button == sf::Mouse::Button::Left &&
-			elements_.at("start").getGlobalBounds().contains(mouse_pos))
-			state_manager_->ChangeState(StateID::kSimulation);
+		bool left_clicked = btn_pressed->button == sf::Mouse::Button::Left;
+		bool start_hovered = elements_.at("start").getGlobalBounds().contains(mouse_pos);
+		bool next_hovered = elements_.at("next_lv").getGlobalBounds().contains(mouse_pos);
+		bool prev_hovered = elements_.at("prev_lv").getGlobalBounds().contains(mouse_pos);
+
+		if (left_clicked) {
+			if (next_hovered)
+				ChangeLevel(1);
+			else if (prev_hovered)
+				ChangeLevel(-1);
+			else if (start_hovered)
+				state_manager_->ChangeState(StateID::kSimulation);
+		}
 	}
 
-	if (const auto* key_pressed = event.getIf<sf::Event::KeyPressed>())
+	// KEYBOARD
+	if (const auto* key = event.getIf<sf::Event::KeyPressed>())
 	{
-		if (key_pressed->code == sf::Keyboard::Key::Enter ||
-			key_pressed->code == sf::Keyboard::Key::Space)
+		switch (key->code) {
+		case sf::Keyboard::Key::Right:	ChangeLevel(1);		break;
+		case sf::Keyboard::Key::Left:	ChangeLevel(-1);	break;
+		case sf::Keyboard::Key::Enter:
+		case sf::Keyboard::Key::Space:
+			state_manager_->SetCurrentLevel(selected_level_);
 			state_manager_->ChangeState(StateID::kSimulation);
+			break;
+		}
 	}
 }
 
 void MainMenuState::Render(sf::RenderTarget& target)
 {
-	target.draw(elements_.at("title"));
-	target.draw(elements_.at("start"));
+	for (const auto& [key, element] : elements_)
+		target.draw(element);
 }
 
 void MainMenuState::LayoutElements()
@@ -64,13 +103,34 @@ void MainMenuState::LayoutElements()
 	constexpr float padding = 50.f;
 	sf::Vector2f cursor = margin;
 
-	// Set origins
-	elements_.at("title").setOrigin({ 0.f, 0.f });
-	elements_.at("start").setOrigin({ 0.f, 0.f });
-
 	elements_.at("title").setPosition(cursor);
-	cursor.y += elements_.at("title").getLocalBounds().size.y + padding;
+	cursor.y += elements_.at("title").getLocalBounds().size.y + (padding * 2);
+
+	elements_.at("level").setPosition(cursor);
+	cursor.y += elements_.at("level").getLocalBounds().size.y + (padding / 2);
+
+	elements_.at("next_lv").setPosition(cursor);
+	cursor.y += elements_.at("next_lv").getLocalBounds().size.y + (padding / 2);
+
+	elements_.at("prev_lv").setPosition(cursor);
+	cursor.y += elements_.at("prev_lv").getLocalBounds().size.y + (padding * 2);
 
 	elements_.at("start").setPosition(cursor);
-	cursor.y += elements_.at("start").getLocalBounds().size.y + padding;
+	cursor.y += elements_.at("start").getLocalBounds().size.y;
+}
+
+void MainMenuState::ChangeLevel(int offset)
+{
+	// Update level
+	if (offset > 0) {
+		selected_level_ = (selected_level_ % 4) + 1;						// Cycle forwards (i.e. 4 -> 1)
+		if (selected_level_ == 2) selected_level_ = 3;						// COMPROMISE: Skip level 2
+	}
+	else {
+		selected_level_ = (selected_level_ == 1) ? 4 : selected_level_ - 1;	// Cycle backwards (i.e. 1 -> 4)
+		if (selected_level_ == 2) selected_level_ = 1;						// COMPROMISE: Skip level 2
+	}
+
+	// Update UI
+	elements_.at("level").setString("Level: " + std::to_string(selected_level_));
 }

--- a/src/SimulationState.cc
+++ b/src/SimulationState.cc
@@ -22,7 +22,7 @@ void SimulationState::Init()
 	// LEVEL
 	is_keypress_ = false;
 	win_state_ = 0;
-	level_->Init();
+	level_->Init(state_manager_->GetCurrentLevel());
 
 	LayoutElements();
 }

--- a/src/SimulationState.cc
+++ b/src/SimulationState.cc
@@ -41,7 +41,8 @@ void SimulationState::HandleInput(const sf::Event event)
 		}
 	}
 
-	if (event.getIf<sf::Event::KeyPressed>() && !is_keypress_ && !level_->IsEnemyTurn() && !win_state_) // to prevent multiple key presses from stacking
+	bool enemy_turn = level_->IsEnemyTurn() && level_->EnemiesExist();
+	if (event.getIf<sf::Event::KeyPressed>() && !is_keypress_ && !enemy_turn && !win_state_) // to prevent multiple key presses from stacking
 	{
 		// Handle input for the level
 		level_->HandleInput(event);


### PR DESCRIPTION
Changes:
- User can now pick one of three levels present in the repository.
- Pressing Enter or Space at the main menu will now start the game, loading the level currently selected.

Fixes:
- Even before the level selector was implemented, if you wanted to load another level via hard-coding the MAP_LOADED constant, pressing Start Game wouldn't actually change the level loaded.
- If no enemies existed in the level, the game would still wait for the enemy's turn.