### PR TITLE
hotfix: level selector graphical glitch and enemy behavior bug

### DIFF
--- a/include/LevelMap.h
+++ b/include/LevelMap.h
@@ -15,7 +15,7 @@ class LevelMap
 {
 public:
 	LevelMap(WindowContext& window)
-		: is_enemyturn(false), player_(nullptr), window_(window) {}
+		: is_enemyturn_(false), player_(nullptr), window_(window) {}
 
 	// CONSTRUCTOR HELPERS
 	void Init(int level);
@@ -26,8 +26,8 @@ public:
 	WindowContext& GetWindowContext() const { return window_; }
 	sf::Vector2f GetGridbounds() const;
 
-	bool IsEnemyTurn() const { return is_enemyturn; }
-	void SetEnemyTurn(bool flag) { is_enemyturn = flag; }
+	bool IsEnemyTurn() const { return is_enemyturn_; }
+	void SetEnemyTurn(bool flag) { is_enemyturn_ = flag; }
 
 	Tile* GetTileAt(const sf::Vector2i& gridpos) const;
 	Tile* GetTileAt(const size_t& i) const;
@@ -61,7 +61,7 @@ public:
 private:
 	WindowContext& window_;
 
-	bool is_enemyturn;
+	bool is_enemyturn_;
 
 	std::vector<std::unique_ptr<Tile>> tiles_;
 	std::vector<std::unique_ptr<Entity>> entities_;

--- a/src/Enemy.cc
+++ b/src/Enemy.cc
@@ -13,10 +13,9 @@ void Enemy::Update(const sf::Time& delta)
 	sf::Vector2i offs;
 	sf::Vector2i new_pos = GetGridPosition();
 
-	if (GetLevelMap()->IsEnemyTurn() && moveclock_.getElapsedTime().asSeconds() >= MOVE_DELAY)
-	{
-		switch (GetType())
-		{
+	bool enemy_turn = level_->IsEnemyTurn() && level_->EnemiesExist();
+	if (enemy_turn && moveclock_.getElapsedTime().asSeconds() >= MOVE_DELAY) {
+		switch (GetType()) {
 		case EntityType::kDevilbot:
 			offs = FindPath(new_pos);
 			new_pos = ResolveCollisions(offs);
@@ -24,8 +23,7 @@ void Enemy::Update(const sf::Time& delta)
 			SetGridPosition(new_pos);
 			Layout();
 
-			switch (moves_)
-			{
+			switch (moves_) {
 			case 0:
 				moves_++; // Increment moves after first move
 				break;

--- a/src/LevelMap.cc
+++ b/src/LevelMap.cc
@@ -20,6 +20,7 @@ void LevelMap::Init(int level)
 	blocks_.clear();
 	collectibles_.clear();
 	player_ = nullptr;
+	is_enemyturn_ = false;
 
 	// INIT TILES
 	for (int y = 0; y < ROW_SIZE; y++)

--- a/src/MainMenuState.cc
+++ b/src/MainMenuState.cc
@@ -27,7 +27,10 @@ void MainMenuState::Init()
 
 	// LEVEL SELECTOR
 	elements_.at("level").setCharacterSize(30);
-	elements_.at("level").setString("Level: " + std::to_string(DEFAULT_LEVEL));
+	if (selected_level_ == DEFAULT_LEVEL)
+		elements_.at("level").setString("Level: " + std::to_string(DEFAULT_LEVEL));
+	else
+		elements_.at("level").setString("Level: " + std::to_string(selected_level_));
 
 	elements_.at("next_lv").setCharacterSize(30);
 	elements_.at("next_lv").setString("Next");

--- a/src/SimulationState.cc
+++ b/src/SimulationState.cc
@@ -29,10 +29,8 @@ void SimulationState::Init()
 
 void SimulationState::HandleInput(const sf::Event event)
 {
-	if (const auto* key = event.getIf<sf::Event::KeyPressed>())
-	{
-		if (key->code == sf::Keyboard::Key::Escape)
-		{
+	if (const auto* key = event.getIf<sf::Event::KeyPressed>()) {
+		if (key->code == sf::Keyboard::Key::Escape) {
 			state_manager_->ChangeState(kMainMenu); // Go back to main menu
 #ifdef _DEBUG
 			std::cout << "INFO: Simulation ended.\n\n";
@@ -42,11 +40,8 @@ void SimulationState::HandleInput(const sf::Event event)
 	}
 
 	bool enemy_turn = level_->IsEnemyTurn() && level_->EnemiesExist();
-	if (event.getIf<sf::Event::KeyPressed>() && !is_keypress_ && !enemy_turn && !win_state_) // to prevent multiple key presses from stacking
-	{
-		// Handle input for the level
+	if (event.getIf<sf::Event::KeyPressed>() && !is_keypress_ && !enemy_turn && !win_state_) {
 		level_->HandleInput(event);
-
 		is_keypress_ = true;
 	}
 	
@@ -64,19 +59,14 @@ void SimulationState::Update(const sf::Time& delta)
 
 	// Update win condition
 	if (player_tile->GetType() == TileType::kStairs)
-	{
 		win_state_ = 1;	// Player reached the stairs, level is complete
-	}
 	else if (level_->IsPlayerCaught())
-	{
 		win_state_ = -1;
-	}
 	else
 		win_state_ = 0; // Player decides not to leave the level for whatever reason
 
 	// Update win text
-	switch (win_state_)
-	{
+	switch (win_state_) {
 	case 1:
 		elements_.at("win").setString(std::string("LEVEL COMPLETE! Press Esc to exit to main menu."));
 		LayoutElements();


### PR DESCRIPTION
Fixes:
- When a simulation with enemies was started after a simulation without enemies, the game would think it was the enemies' turn.
- When the user returns to the main menu after a simulation ends, the level selector displayed `DEFAULT_LEVEL` instead of `selected_level_`.
